### PR TITLE
feat: cache imported AES-GCM key in LocalSave to avoid repeated importKey calls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -240,7 +240,7 @@ class LocalSave {
      */
     private async getEncryptKey() {
         const sourceKey = this.encryptionKey;
-        if (typeof sourceKey !== 'string' || !isEncryptionKeyDefined(sourceKey)) {
+        if (!isEncryptionKeyDefined(sourceKey)) {
             throw new LocalSaveEncryptionKeyError(`Encryption key is not configured`);
         }
         if (!isValidEncryptionKey(sourceKey)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ import {
 class LocalSave {
     dbName: DBName = 'LocalSave';
     encryptionKey?: EncryptionKey;
+    private cachedCryptoKeyPromise?: Promise<CryptoKey>;
+    private cachedCryptoKeySource?: EncryptionKey;
     categories: Category[] = ['userData'];
     expiryThreshold: PositiveNumber = 30;
     blockedTimeoutThreshold: PositiveNumber = 10 * 1000;
@@ -237,22 +239,41 @@ class LocalSave {
      * @throws {LocalSaveEncryptionKeyError} If the encryption key length is not 16, 24, or 32 characters.
      */
     private async getEncryptKey() {
-        if (!isEncryptionKeyDefined(this.encryptionKey)) {
+        const sourceKey = this.encryptionKey;
+        if (typeof sourceKey !== 'string' || !isEncryptionKeyDefined(sourceKey)) {
             throw new LocalSaveEncryptionKeyError(`Encryption key is not configured`);
         }
-        if (!!this.encryptionKey && !isValidEncryptionKey(this.encryptionKey)) {
+        if (!isValidEncryptionKey(sourceKey)) {
             throw new LocalSaveEncryptionKeyError('Encryption key should be of length 16, 24, or 32 characters');
         }
-        const encoder = new TextEncoder();
-        const keyBytes = encoder.encode(this.encryptionKey);
-        const key = await crypto.subtle.importKey('raw', keyBytes, { name: 'AES-GCM' }, false, ['encrypt', 'decrypt']);
-        if (this.printLogs) {
-            Logger.debug(`Encryption key retrieved successfully`, {
-                keyLength: this.encryptionKey?.length,
-                keyBytesLength: keyBytes.length,
-            });
+        if (this.cachedCryptoKeyPromise && this.cachedCryptoKeySource === sourceKey) {
+            return this.cachedCryptoKeyPromise;
         }
-        return key;
+        const encoder = new TextEncoder();
+        const keyBytes = encoder.encode(sourceKey);
+        const importPromise = crypto.subtle
+            .importKey('raw', keyBytes, { name: 'AES-GCM' }, false, ['encrypt', 'decrypt'])
+            .then((key) => {
+                if (this.printLogs) {
+                    Logger.debug(`Encryption key retrieved successfully`, {
+                        keyLength: sourceKey.length,
+                        keyBytesLength: keyBytes.length,
+                    });
+                }
+                return key;
+            })
+            .catch((error) => {
+                if (this.cachedCryptoKeyPromise === importPromise) {
+                    this.cachedCryptoKeyPromise = undefined;
+                    this.cachedCryptoKeySource = undefined;
+                }
+                throw error;
+            });
+
+        this.cachedCryptoKeySource = sourceKey;
+        this.cachedCryptoKeyPromise = importPromise;
+
+        return importPromise;
     }
 
     /**

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -6,7 +6,7 @@
  * @returns `true` if the key is defined.
  */
 export function isEncryptionKeyDefined(key: string | undefined | null) {
-    return !!key && key != '' && key.length > 0;
+    return !!key && typeof key === 'string' && key != '' && key.length > 0;
 }
 
 /**

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,12 +1,12 @@
 /**
  * Validates the encryption key.
- * This function checks if the provided key is defined and has a length.
+ * This function checks if the provided key is a string and has a length.
  *
  * @param key - The encryption key to validate.
  * @returns `true` if the key is defined.
  */
-export function isEncryptionKeyDefined(key: string | undefined | null) {
-    return !!key && typeof key === 'string' && key != '' && key.length > 0;
+export function isEncryptionKeyDefined(key: string | undefined | null): key is string {
+    return typeof key === 'string' && key.length > 0;
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR improves encryption/decryption performance by caching the imported CryptoKey instead of re-importing it for every encrypted operation.

## Changes
- Added in-memory cache fields for the imported key Promise and its source encryption key.
- Updated getEncryptKey to:
  - validate the configured encryption key
  - return the cached CryptoKey Promise when the key is unchanged
  - create and cache a new import Promise when needed
  - clear cache state if key import fails

## Why
Previously, each encrypted set/get path could trigger a fresh crypto.subtle.importKey call, which adds avoidable overhead. Reusing the imported key reduces repeated crypto setup work and improves runtime efficiency under frequent encrypted operations.

## Safety
- Cache is only reused when the current encryption key exactly matches the cached source key.
- Failed imports clear the cache so subsequent calls can retry cleanly.
- No API changes and no data format changes.

## Breaking Changes
None.