### PR TITLE
Track IndexedDB transaction completion for write operations in `LocalSave`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -464,6 +464,20 @@ class LocalSave {
             }
             const store = await this.getStore(category, 'readwrite');
             return new Promise<true>((resolve, reject) => {
+                let settled = false;
+
+                const settleResolve = () => {
+                    if (settled) return;
+                    settled = true;
+                    resolve(true);
+                };
+
+                const settleReject = (error: LocalSaveError) => {
+                    if (settled) return;
+                    settled = true;
+                    reject(error);
+                };
+
                 const putRequest = store.put(payload, itemKey);
                 putRequest.onsuccess = () => {
                     if (this.printLogs) {
@@ -472,7 +486,6 @@ class LocalSave {
                             itemKey,
                         });
                     }
-                    resolve(true);
                 };
                 putRequest.onerror = () => {
                     if (this.printLogs) {
@@ -481,8 +494,31 @@ class LocalSave {
                             putRequest.error,
                         );
                     }
-                    reject(new LocalSaveError(putRequest.error?.message ?? 'Error storing data'));
+                    settleReject(new LocalSaveError(putRequest.error?.message ?? 'Error storing data'));
                 };
+
+                store.transaction.addEventListener('complete', () => {
+                    settleResolve();
+                });
+
+                store.transaction.addEventListener('error', () => {
+                    if (this.printLogs) {
+                        Logger.error(
+                            `LocalSaveError during transaction commit while storing data [category:${category} / key:${itemKey}]`,
+                            store.transaction.error,
+                        );
+                    }
+                    settleReject(
+                        new LocalSaveError(store.transaction.error?.message ?? 'Error committing storage transaction'),
+                    );
+                });
+
+                store.transaction.addEventListener('abort', () => {
+                    if (this.printLogs) {
+                        Logger.warn(`Transaction aborted while storing data [category:${category} / key:${itemKey}]`);
+                    }
+                    settleReject(new LocalSaveError('Transaction aborted while storing data'));
+                });
             });
         } catch (error) {
             if (this.printLogs) {
@@ -627,6 +663,20 @@ class LocalSave {
         }
         const store = await this.getStore(category, 'readwrite');
         return new Promise<true>((resolve, reject) => {
+            let settled = false;
+
+            const settleResolve = () => {
+                if (settled) return;
+                settled = true;
+                resolve(true);
+            };
+
+            const settleReject = (error: LocalSaveError) => {
+                if (settled) return;
+                settled = true;
+                reject(error);
+            };
+
             const deleteRequest = store.delete(itemKey);
             deleteRequest.onsuccess = () => {
                 if (this.printLogs) {
@@ -635,7 +685,6 @@ class LocalSave {
                         itemKey,
                     });
                 }
-                return resolve(true);
             };
             deleteRequest.onerror = () => {
                 if (this.printLogs) {
@@ -644,8 +693,31 @@ class LocalSave {
                         deleteRequest.error,
                     );
                 }
-                return reject(new LocalSaveError(deleteRequest.error?.message ?? 'Error removing data'));
+                settleReject(new LocalSaveError(deleteRequest.error?.message ?? 'Error removing data'));
             };
+
+            store.transaction.addEventListener('complete', () => {
+                settleResolve();
+            });
+
+            store.transaction.addEventListener('error', () => {
+                if (this.printLogs) {
+                    Logger.error(
+                        `LocalSaveError during transaction commit while removing data [category:${category} / key:${itemKey}]`,
+                        store.transaction.error,
+                    );
+                }
+                settleReject(
+                    new LocalSaveError(store.transaction.error?.message ?? 'Error committing removal transaction'),
+                );
+            });
+
+            store.transaction.addEventListener('abort', () => {
+                if (this.printLogs) {
+                    Logger.warn(`Transaction aborted while removing data [category:${category} / key:${itemKey}]`);
+                }
+                settleReject(new LocalSaveError('Transaction aborted while removing data'));
+            });
         });
     }
 
@@ -664,6 +736,20 @@ class LocalSave {
         }
         const store = await this.getStore(category, 'readwrite');
         return new Promise<true>((resolve, reject) => {
+            let settled = false;
+
+            const settleResolve = () => {
+                if (settled) return;
+                settled = true;
+                resolve(true);
+            };
+
+            const settleReject = (error: LocalSaveError) => {
+                if (settled) return;
+                settled = true;
+                reject(error);
+            };
+
             const clearRequest = store.clear();
             clearRequest.onsuccess = () => {
                 if (this.printLogs) {
@@ -673,7 +759,6 @@ class LocalSave {
                         version: store.transaction.db.version,
                     });
                 }
-                return resolve(true);
             };
             clearRequest.onerror = () => {
                 if (this.printLogs) {
@@ -682,8 +767,31 @@ class LocalSave {
                         clearRequest.error,
                     );
                 }
-                return reject(new LocalSaveError(clearRequest.error?.message ?? 'Error clearing data'));
+                settleReject(new LocalSaveError(clearRequest.error?.message ?? 'Error clearing data'));
             };
+
+            store.transaction.addEventListener('complete', () => {
+                settleResolve();
+            });
+
+            store.transaction.addEventListener('error', () => {
+                if (this.printLogs) {
+                    Logger.error(
+                        `LocalSaveError during transaction commit while clearing data [category:${category} / dbName:${this.dbName} / version:${store.transaction.db.version}]`,
+                        store.transaction.error,
+                    );
+                }
+                settleReject(
+                    new LocalSaveError(store.transaction.error?.message ?? 'Error committing clear transaction'),
+                );
+            });
+
+            store.transaction.addEventListener('abort', () => {
+                if (this.printLogs) {
+                    Logger.warn(`Transaction aborted while clearing data [category:${category}]`);
+                }
+                settleReject(new LocalSaveError('Transaction aborted while clearing data'));
+            });
         });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -335,9 +335,13 @@ class LocalSave {
                 reject(error);
             };
 
-            request.onerror = () => {
-                requestError = onRequestError(request.error);
-            };
+            request.addEventListener(
+                'error',
+                () => {
+                    requestError = onRequestError(request.error);
+                },
+                { once: true },
+            );
 
             transaction.addEventListener(
                 'complete',

--- a/src/index.ts
+++ b/src/index.ts
@@ -316,11 +316,12 @@ class LocalSave {
         transaction: IDBTransaction;
         onRequestError: (error: DOMException | null) => LocalSaveError;
         onTransactionError: (error: DOMException | null) => LocalSaveError;
-        onTransactionAbort: () => LocalSaveError;
+        onTransactionAbort: (error: DOMException | null) => LocalSaveError;
         onTransactionComplete?: () => void;
     }): Promise<true> {
         return new Promise<true>((resolve, reject) => {
             let settled = false;
+            let requestError: LocalSaveError | undefined;
 
             const settleResolve = () => {
                 if (settled) return;
@@ -335,13 +336,17 @@ class LocalSave {
             };
 
             request.onerror = () => {
-                settleReject(onRequestError(request.error));
+                requestError = onRequestError(request.error);
             };
 
             transaction.addEventListener(
                 'complete',
                 () => {
                     if (settled) return;
+                    if (requestError) {
+                        settleReject(requestError);
+                        return;
+                    }
                     onTransactionComplete?.();
                     settleResolve();
                 },
@@ -352,7 +357,7 @@ class LocalSave {
                 'error',
                 () => {
                     if (settled) return;
-                    settleReject(onTransactionError(transaction.error));
+                    settleReject(requestError ?? onTransactionError(transaction.error));
                 },
                 { once: true },
             );
@@ -361,7 +366,7 @@ class LocalSave {
                 'abort',
                 () => {
                     if (settled) return;
-                    settleReject(onTransactionAbort());
+                    settleReject(requestError ?? onTransactionAbort(transaction.error));
                 },
                 { once: true },
             );
@@ -561,11 +566,14 @@ class LocalSave {
                     }
                     return new LocalSaveError(error?.message ?? 'Error committing storage transaction');
                 },
-                onTransactionAbort: () => {
+                onTransactionAbort: (error: DOMException | null) => {
                     if (this.printLogs) {
-                        Logger.warn(`Transaction aborted while storing data [category:${category} / key:${itemKey}]`);
+                        Logger.warn(
+                            `Transaction aborted while storing data [category:${category} / key:${itemKey}]`,
+                            error,
+                        );
                     }
-                    return new LocalSaveError('Transaction aborted while storing data');
+                    return new LocalSaveError(error?.message ?? 'Transaction aborted while storing data');
                 },
                 onTransactionComplete: () => {
                     if (this.printLogs) {
@@ -747,11 +755,14 @@ class LocalSave {
                 }
                 return new LocalSaveError(error?.message ?? 'Error committing removal transaction');
             },
-            onTransactionAbort: () => {
+            onTransactionAbort: (error: DOMException | null) => {
                 if (this.printLogs) {
-                    Logger.warn(`Transaction aborted while removing data [category:${category} / key:${itemKey}]`);
+                    Logger.warn(
+                        `Transaction aborted while removing data [category:${category} / key:${itemKey}]`,
+                        error,
+                    );
                 }
-                return new LocalSaveError('Transaction aborted while removing data');
+                return new LocalSaveError(error?.message ?? 'Transaction aborted while removing data');
             },
             onTransactionComplete: () => {
                 if (this.printLogs) {
@@ -799,11 +810,11 @@ class LocalSave {
                 }
                 return new LocalSaveError(error?.message ?? 'Error committing clear transaction');
             },
-            onTransactionAbort: () => {
+            onTransactionAbort: (error: DOMException | null) => {
                 if (this.printLogs) {
-                    Logger.warn(`Transaction aborted while clearing data [category:${category}]`);
+                    Logger.warn(`Transaction aborted while clearing data [category:${category}]`, error);
                 }
-                return new LocalSaveError('Transaction aborted while clearing data');
+                return new LocalSaveError(error?.message ?? 'Transaction aborted while clearing data');
             },
             onTransactionComplete: () => {
                 if (this.printLogs) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -559,7 +559,9 @@ class LocalSave {
                     if (this.printLogs) {
                         Logger.error(`LocalSaveError storing data [category:${category} / key:${itemKey}]`, error);
                     }
-                    return new LocalSaveError(error?.message ?? 'Error storing data');
+                    return new LocalSaveError(error?.message ?? 'Error storing data', {
+                        cause: error ?? undefined,
+                    });
                 },
                 onTransactionError: (error) => {
                     if (this.printLogs) {
@@ -568,7 +570,9 @@ class LocalSave {
                             error,
                         );
                     }
-                    return new LocalSaveError(error?.message ?? 'Error committing storage transaction');
+                    return new LocalSaveError(error?.message ?? 'Error committing storage transaction', {
+                        cause: error ?? undefined,
+                    });
                 },
                 onTransactionAbort: (error: DOMException | null) => {
                     if (this.printLogs) {
@@ -577,7 +581,9 @@ class LocalSave {
                             error,
                         );
                     }
-                    return new LocalSaveError(error?.message ?? 'Transaction aborted while storing data');
+                    return new LocalSaveError(error?.message ?? 'Transaction aborted while storing data', {
+                        cause: error ?? undefined,
+                    });
                 },
                 onTransactionComplete: () => {
                     if (this.printLogs) {
@@ -748,7 +754,9 @@ class LocalSave {
                 if (this.printLogs) {
                     Logger.error(`Failed to remove data from [category:${category} / key:${itemKey}]`, error);
                 }
-                return new LocalSaveError(error?.message ?? 'Error removing data');
+                return new LocalSaveError(error?.message ?? 'Error removing data', {
+                    cause: error ?? undefined,
+                });
             },
             onTransactionError: (error: DOMException | null) => {
                 if (this.printLogs) {
@@ -757,7 +765,9 @@ class LocalSave {
                         error,
                     );
                 }
-                return new LocalSaveError(error?.message ?? 'Error committing removal transaction');
+                return new LocalSaveError(error?.message ?? 'Error committing removal transaction', {
+                    cause: error ?? undefined,
+                });
             },
             onTransactionAbort: (error: DOMException | null) => {
                 if (this.printLogs) {
@@ -766,7 +776,9 @@ class LocalSave {
                         error,
                     );
                 }
-                return new LocalSaveError(error?.message ?? 'Transaction aborted while removing data');
+                return new LocalSaveError(error?.message ?? 'Transaction aborted while removing data', {
+                    cause: error ?? undefined,
+                });
             },
             onTransactionComplete: () => {
                 if (this.printLogs) {
@@ -803,7 +815,9 @@ class LocalSave {
                         error,
                     );
                 }
-                return new LocalSaveError(error?.message ?? 'Error clearing data');
+                return new LocalSaveError(error?.message ?? 'Error clearing data', {
+                    cause: error ?? undefined,
+                });
             },
             onTransactionError: (error) => {
                 if (this.printLogs) {
@@ -812,13 +826,17 @@ class LocalSave {
                         error,
                     );
                 }
-                return new LocalSaveError(error?.message ?? 'Error committing clear transaction');
+                return new LocalSaveError(error?.message ?? 'Error committing clear transaction', {
+                    cause: error ?? undefined,
+                });
             },
             onTransactionAbort: (error: DOMException | null) => {
                 if (this.printLogs) {
                     Logger.warn(`Transaction aborted while clearing data [category:${category}]`, error);
                 }
-                return new LocalSaveError(error?.message ?? 'Transaction aborted while clearing data');
+                return new LocalSaveError(error?.message ?? 'Transaction aborted while clearing data', {
+                    cause: error ?? undefined,
+                });
             },
             onTransactionComplete: () => {
                 if (this.printLogs) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -573,7 +573,18 @@ class LocalSave {
                             if (this.printLogs) {
                                 Logger.error(`Triggering clear for all data for category since decryption failed`);
                             }
-                            void this.clear(category);
+                            try {
+                                await this.clear(category);
+                            } catch (clearError) {
+                                if (this.printLogs) {
+                                    Logger.error(`Failed to clear data after decryption failure`, clearError);
+                                }
+                                return reject(
+                                    new LocalSaveError('Data decryption failed and category clearing failed', {
+                                        cause: clearError instanceof Error ? clearError : undefined,
+                                    }),
+                                );
+                            }
                         }
                         return reject(
                             new LocalSaveError(error instanceof Error ? error.message : 'Failed to decrypt data'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -289,6 +289,86 @@ class LocalSave {
     }
 
     /**
+     * Wraps an IndexedDB request with transaction completion tracking.
+     * Ensures the promise only resolves/rejects after the transaction fully completes,
+     * not just when the request succeeds.
+     *
+     * @internal
+     *
+     * @param options The request and transaction handlers to track.
+     * @param options.request The IndexedDB request to track.
+     * @param options.transaction The IndexedDB transaction containing the request.
+     * @param options.onRequestError Handler to convert request errors to LocalSaveError.
+     * @param options.onTransactionError Handler to convert transaction errors to LocalSaveError.
+     * @param options.onTransactionAbort Handler to handle transaction aborts.
+     * @param options.onTransactionComplete Handler to run when the transaction completes successfully.
+     * @returns A promise that resolves when the transaction completes successfully.
+     */
+    private wrapRequestWithTransaction({
+        request,
+        transaction,
+        onRequestError,
+        onTransactionError,
+        onTransactionAbort,
+        onTransactionComplete,
+    }: {
+        request: IDBRequest;
+        transaction: IDBTransaction;
+        onRequestError: (error: DOMException | null) => LocalSaveError;
+        onTransactionError: (error: DOMException | null) => LocalSaveError;
+        onTransactionAbort: () => LocalSaveError;
+        onTransactionComplete?: () => void;
+    }): Promise<true> {
+        return new Promise<true>((resolve, reject) => {
+            let settled = false;
+
+            const settleResolve = () => {
+                if (settled) return;
+                settled = true;
+                resolve(true);
+            };
+
+            const settleReject = (error: LocalSaveError) => {
+                if (settled) return;
+                settled = true;
+                reject(error);
+            };
+
+            request.onerror = () => {
+                settleReject(onRequestError(request.error));
+            };
+
+            transaction.addEventListener(
+                'complete',
+                () => {
+                    if (settled) return;
+                    onTransactionComplete?.();
+                    settleResolve();
+                },
+                { once: true },
+            );
+
+            transaction.addEventListener(
+                'error',
+                () => {
+                    if (settled) return;
+                    settleReject(onTransactionError(transaction.error));
+                },
+                { once: true },
+            );
+
+            transaction.addEventListener(
+                'abort',
+                () => {
+                    if (settled) return;
+                    settleReject(onTransactionAbort());
+                },
+                { once: true },
+            );
+        });
+    }
+
+    /**
      * Retrieves the encryption key as a CryptoKey object.
      *
      * @internal
@@ -463,62 +543,38 @@ class LocalSave {
                 payload = await this.encryptData(payload);
             }
             const store = await this.getStore(category, 'readwrite');
-            return new Promise<true>((resolve, reject) => {
-                let settled = false;
-
-                const settleResolve = () => {
-                    if (settled) return;
-                    settled = true;
-                    resolve(true);
-                };
-
-                const settleReject = (error: LocalSaveError) => {
-                    if (settled) return;
-                    settled = true;
-                    reject(error);
-                };
-
-                const putRequest = store.put(payload, itemKey);
-                putRequest.onsuccess = () => {
+            return this.wrapRequestWithTransaction({
+                request: store.put(payload, itemKey),
+                transaction: store.transaction,
+                onRequestError: (error) => {
+                    if (this.printLogs) {
+                        Logger.error(`LocalSaveError storing data [category:${category} / key:${itemKey}]`, error);
+                    }
+                    return new LocalSaveError(error?.message ?? 'Error storing data');
+                },
+                onTransactionError: (error) => {
+                    if (this.printLogs) {
+                        Logger.error(
+                            `LocalSaveError during transaction commit while storing data [category:${category} / key:${itemKey}]`,
+                            error,
+                        );
+                    }
+                    return new LocalSaveError(error?.message ?? 'Error committing storage transaction');
+                },
+                onTransactionAbort: () => {
+                    if (this.printLogs) {
+                        Logger.warn(`Transaction aborted while storing data [category:${category} / key:${itemKey}]`);
+                    }
+                    return new LocalSaveError('Transaction aborted while storing data');
+                },
+                onTransactionComplete: () => {
                     if (this.printLogs) {
                         Logger.debug(`Data stored successfully`, {
                             category,
                             itemKey,
                         });
                     }
-                };
-                putRequest.onerror = () => {
-                    if (this.printLogs) {
-                        Logger.error(
-                            `LocalSaveError storing data [category:${category} / key:${itemKey}]`,
-                            putRequest.error,
-                        );
-                    }
-                    settleReject(new LocalSaveError(putRequest.error?.message ?? 'Error storing data'));
-                };
-
-                store.transaction.addEventListener('complete', () => {
-                    settleResolve();
-                });
-
-                store.transaction.addEventListener('error', () => {
-                    if (this.printLogs) {
-                        Logger.error(
-                            `LocalSaveError during transaction commit while storing data [category:${category} / key:${itemKey}]`,
-                            store.transaction.error,
-                        );
-                    }
-                    settleReject(
-                        new LocalSaveError(store.transaction.error?.message ?? 'Error committing storage transaction'),
-                    );
-                });
-
-                store.transaction.addEventListener('abort', () => {
-                    if (this.printLogs) {
-                        Logger.warn(`Transaction aborted while storing data [category:${category} / key:${itemKey}]`);
-                    }
-                    settleReject(new LocalSaveError('Transaction aborted while storing data'));
-                });
+                },
             });
         } catch (error) {
             if (this.printLogs) {
@@ -673,62 +729,38 @@ class LocalSave {
             });
         }
         const store = await this.getStore(category, 'readwrite');
-        return new Promise<true>((resolve, reject) => {
-            let settled = false;
-
-            const settleResolve = () => {
-                if (settled) return;
-                settled = true;
-                resolve(true);
-            };
-
-            const settleReject = (error: LocalSaveError) => {
-                if (settled) return;
-                settled = true;
-                reject(error);
-            };
-
-            const deleteRequest = store.delete(itemKey);
-            deleteRequest.onsuccess = () => {
+        return this.wrapRequestWithTransaction({
+            request: store.delete(itemKey),
+            transaction: store.transaction,
+            onRequestError: (error: DOMException | null) => {
+                if (this.printLogs) {
+                    Logger.error(`Failed to remove data from [category:${category} / key:${itemKey}]`, error);
+                }
+                return new LocalSaveError(error?.message ?? 'Error removing data');
+            },
+            onTransactionError: (error: DOMException | null) => {
+                if (this.printLogs) {
+                    Logger.error(
+                        `LocalSaveError during transaction commit while removing data [category:${category} / key:${itemKey}]`,
+                        error,
+                    );
+                }
+                return new LocalSaveError(error?.message ?? 'Error committing removal transaction');
+            },
+            onTransactionAbort: () => {
+                if (this.printLogs) {
+                    Logger.warn(`Transaction aborted while removing data [category:${category} / key:${itemKey}]`);
+                }
+                return new LocalSaveError('Transaction aborted while removing data');
+            },
+            onTransactionComplete: () => {
                 if (this.printLogs) {
                     Logger.debug(`Data removed successfully`, {
                         category,
                         itemKey,
                     });
                 }
-            };
-            deleteRequest.onerror = () => {
-                if (this.printLogs) {
-                    Logger.error(
-                        `Failed to remove data from [category:${category} / key:${itemKey}]`,
-                        deleteRequest.error,
-                    );
-                }
-                settleReject(new LocalSaveError(deleteRequest.error?.message ?? 'Error removing data'));
-            };
-
-            store.transaction.addEventListener('complete', () => {
-                settleResolve();
-            });
-
-            store.transaction.addEventListener('error', () => {
-                if (this.printLogs) {
-                    Logger.error(
-                        `LocalSaveError during transaction commit while removing data [category:${category} / key:${itemKey}]`,
-                        store.transaction.error,
-                    );
-                }
-                settleReject(
-                    new LocalSaveError(store.transaction.error?.message ?? 'Error committing removal transaction'),
-                );
-            });
-
-            store.transaction.addEventListener('abort', () => {
-                if (this.printLogs) {
-                    Logger.warn(`Transaction aborted while removing data [category:${category} / key:${itemKey}]`);
-                }
-                settleReject(new LocalSaveError('Transaction aborted while removing data'));
-            });
+            },
         });
     }
 
@@ -746,23 +778,34 @@ class LocalSave {
             Logger.debug(`clear() called to store all data under '${category}' category`);
         }
         const store = await this.getStore(category, 'readwrite');
-        return new Promise<true>((resolve, reject) => {
-            let settled = false;
-
-            const settleResolve = () => {
-                if (settled) return;
-                settled = true;
-                resolve(true);
-            };
-
-            const settleReject = (error: LocalSaveError) => {
-                if (settled) return;
-                settled = true;
-                reject(error);
-            };
-
-            const clearRequest = store.clear();
-            clearRequest.onsuccess = () => {
+        return this.wrapRequestWithTransaction({
+            request: store.clear(),
+            transaction: store.transaction,
+            onRequestError: (error) => {
+                if (this.printLogs) {
+                    Logger.error(
+                        `LocalSaveError clearing data [category:${category} / dbName:${this.dbName} / version:${store.transaction.db.version}]`,
+                        error,
+                    );
+                }
+                return new LocalSaveError(error?.message ?? 'Error clearing data');
+            },
+            onTransactionError: (error) => {
+                if (this.printLogs) {
+                    Logger.error(
+                        `LocalSaveError during transaction commit while clearing data [category:${category} / dbName:${this.dbName} / version:${store.transaction.db.version}]`,
+                        error,
+                    );
+                }
+                return new LocalSaveError(error?.message ?? 'Error committing clear transaction');
+            },
+            onTransactionAbort: () => {
+                if (this.printLogs) {
+                    Logger.warn(`Transaction aborted while clearing data [category:${category}]`);
+                }
+                return new LocalSaveError('Transaction aborted while clearing data');
+            },
+            onTransactionComplete: () => {
                 if (this.printLogs) {
                     Logger.debug(`Data cleared successfully`, {
                         category,
@@ -770,39 +813,7 @@ class LocalSave {
                         version: store.transaction.db.version,
                     });
                 }
-            };
-            clearRequest.onerror = () => {
-                if (this.printLogs) {
-                    Logger.error(
-                        `LocalSaveError clearing data [category:${category} / dbName:${this.dbName} / version:${store.transaction.db.version}]`,
-                        clearRequest.error,
-                    );
-                }
-                settleReject(new LocalSaveError(clearRequest.error?.message ?? 'Error clearing data'));
-            };
-
-            store.transaction.addEventListener('complete', () => {
-                settleResolve();
-            });
-
-            store.transaction.addEventListener('error', () => {
-                if (this.printLogs) {
-                    Logger.error(
-                        `LocalSaveError during transaction commit while clearing data [category:${category} / dbName:${this.dbName} / version:${store.transaction.db.version}]`,
-                        store.transaction.error,
-                    );
-                }
-                settleReject(
-                    new LocalSaveError(store.transaction.error?.message ?? 'Error committing clear transaction'),
-                );
-            });
-
-            store.transaction.addEventListener('abort', () => {
-                if (this.printLogs) {
-                    Logger.warn(`Transaction aborted while clearing data [category:${category}]`);
-                }
-                settleReject(new LocalSaveError('Transaction aborted while clearing data'));
-            });
+            },
         });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -429,7 +429,9 @@ class LocalSave {
             if (this.printLogs) {
                 Logger.error(`Data decryption failed`, error);
             }
-            throw new LocalSaveError(`Data decryption failed`);
+            throw new LocalSaveError(`Data decryption failed`, {
+                cause: error instanceof Error ? error : undefined,
+            });
         }
     }
 


### PR DESCRIPTION
**Description**
This change makes `set`, `remove`, and `clear` wait for the IndexedDB transaction to fully complete before resolving. Previously, these methods could resolve on request success even though the write was still only pending at the transaction level.

The update makes write behavior more accurate and predictable by:
- resolving only on transaction `complete`
- rejecting on transaction `error` or `abort`
- keeping the public API unchanged

The result is clearer transaction tracking and a stronger commit guarantee for write operations.