### PR TITLE
feat: standardize LocalSave expiration threshold to milliseconds

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,54 @@
 - Preserve the public API and behavior unless a change request explicitly requires a breaking update.
 - Keep runtime dependencies at zero unless explicitly requested.
 
+## Implementation Guidance
+
+## Current Implementation Details (Source of Truth)
+
+- Core implementation lives in `src/index.ts` in class `LocalSave`; preserve method signatures and return contracts.
+- Default runtime config is:
+    - `dbName: "LocalSave"`
+    - `categories: ["userData"]`
+    - `expiryThreshold: 30 * 24 * 60 * 60 * 1000` (ms)
+    - `blockedTimeoutThreshold: 10000` (ms)
+    - `clearOnDecryptError: true`
+    - `printLogs: false`
+    - `encryptionKey: undefined`
+- Constructor validation behavior must be preserved:
+    - encryption key must be non-whitespace and length `16 | 24 | 32`
+    - `expiryThreshold` and `blockedTimeoutThreshold` must be finite positive numbers
+    - invalid values throw `LocalSaveConfigError`
+- Storage format behavior must be preserved:
+    - without encryption, store `DBItem` object `{ timestamp, data }`
+    - with encryption, store a base64 string containing `IV(12 bytes) + AES-GCM ciphertext`
+- Encryption/decryption behavior must be preserved:
+    - AES-GCM key import via `crypto.subtle.importKey("raw", ...)`
+    - lazy encoder/decoder initialization and cached `CryptoKey` reuse for the same key source
+    - decryption failures throw `LocalSaveError("Data decryption failed")`
+- Category and store behavior must be preserved:
+    - `getStore()` auto-creates missing object stores only when the category exists in configured `categories`
+    - unknown category access rejects with `LocalSaveError`
+    - `listCategories()` reflects actual object stores from IndexedDB
+- Operation semantics to keep stable:
+    - `set(category, key, data) -> Promise<true>`
+    - `get(category, key) -> Promise<DBItem | null>`
+    - `listKeys(category) -> Promise<string[]>`
+    - `remove(category, key) -> Promise<true>`
+    - `clear(category) -> Promise<true>`
+    - `expire(thresholdMs?) -> Promise<true>` and rejects for non-positive/invalid `thresholdMs`
+    - `destroy() -> Promise<true>`
+- IndexedDB transaction behavior to preserve:
+    - write methods resolve only after transaction completion (not just request success)
+    - blocked open/delete operations use timeout based on `blockedTimeoutThreshold`
+    - database connections are closed on transaction end and versionchange events
+- `clearOnDecryptError` behavior is test-backed and must remain unchanged:
+    - `true`: failed decrypt in `get()`/`expire()` clears affected category
+    - `false`: failed decrypt does not clear category data
+- Error classes are part of expected behavior and should remain meaningful and distinct:
+    - `LocalSaveError`
+    - `LocalSaveConfigError`
+    - `LocalSaveEncryptionKeyError`
+
 ## Code Style and Scope
 
 - Prefer small, targeted edits over broad refactors.
@@ -21,6 +69,8 @@
     - category-aware operations (`set`, `get`, `listKeys`, `clear`, `remove`)
 - Preserve encryption-path correctness and error handling (`clearOnDecryptError`, encryption key validation).
 - Do not silently change default config behavior.
+- Keep `expire()` logic category-wide and timestamp-driven (milliseconds threshold).
+- Keep IndexedDB blocked timeout handling aligned between `openDB()` and `destroy()`.
 
 ## Testing Guidance
 

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -3,6 +3,8 @@ name: CI
 on:
     pull_request:
     push:
+        branches:
+            - main
     workflow_dispatch:
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pnpm add @febkosq8/local-save
 | **_dbName_**                  | `string`   | `"LocalSave"`  | Name of the IndexedDB database.                                                                                                                        |
 | **_encryptionKey_**           | `string`   | `undefined`    | Encryption key that should be either [16, 24, or 32] characters to be used for AES-GCM encryption. If not provided, data will be stored in plain text. |
 | **_categories_**              | `string[]` | `["userData"]` | Array of categories (Object store names).                                                                                                              |
-| **_expiryThreshold_**         | `number`   | `30`           | Data expiration threshold in days.                                                                                                                     |
+| **_expiryThreshold_**         | `number`   | `2592000000`   | Data expiration threshold in milliseconds.                                                                                                             |
 | **_blockedTimeoutThreshold_** | `number`   | `10000`        | Timeout in milliseconds before blocked IndexedDB open/delete requests fail.                                                                            |
 | **_clearOnDecryptError_**     | `boolean`  | `true`         | Whether to clear a category if decryption fails.                                                                                                       |
 | **_printLogs_**               | `boolean`  | `false`        | Whether to print logs (Debug and errors).                                                                                                              |
@@ -64,7 +64,7 @@ import LocalSave from "@febkosq8/local-save";
 const localSaveConfig = {
   encryptionKey: "MyRandEncryptKeyThatIs32CharLong", // Encryption key for data
   categories: ["userData", "settings"], // Define categories for data storage
-  expiryThreshold: 14, // Clear data older than 14 days
+  expiryThreshold: 14 * 24 * 60 * 60 * 1000, // Clear data older than 14 days (in ms)
   blockedTimeoutThreshold: 15000, // Wait up to 15s when IndexedDB requests are blocked
 };
 const localSave = new LocalSave(localSaveConfig);
@@ -131,7 +131,7 @@ Clear all expired data from all categories
 ```typescript
 // If a value is provided, it will override the default expiry threshold
 // This can be placed on top of the file to clear expired data on page load
-await localSave.expire(14); // Clear data older than 14 days from all categories
+await localSave.expire(14 * 24 * 60 * 60 * 1000); // Clear data older than 14 days from all categories (in ms)
 ```
 
 ### Destroying the entire database

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ class LocalSave {
     private cachedCryptoKeyPromise?: Promise<CryptoKey>;
     private cachedCryptoKeySource?: EncryptionKey;
     categories: Category[] = ['userData'];
-    expiryThreshold: PositiveNumber = 30;
+    expiryThreshold: PositiveNumber = 30 * 24 * 60 * 60 * 1000;
     blockedTimeoutThreshold: PositiveNumber = 10 * 1000;
     clearOnDecryptError: boolean = true;
     printLogs: boolean = false;
@@ -37,7 +37,7 @@ class LocalSave {
      * @param config.dbName Optional IndexedDB database name override.
      * @param config.encryptionKey Optional AES-GCM key (no whitespace, length 16, 24, or 32).
      * @param config.categories Optional list of object store categories to use.
-     * @param config.expiryThreshold Optional default expiration window in days.
+     * @param config.expiryThreshold Optional default expiration window in milliseconds.
      * @param config.blockedTimeoutThreshold Optional timeout in milliseconds for blocked open/delete requests.
      * @param config.clearOnDecryptError Optional flag to clear a category when decrypt fails.
      * @param config.printLogs Optional flag to enable debug/error logging.
@@ -855,7 +855,7 @@ class LocalSave {
     }
 
     /**
-     * Expires data older than the specified number of days.
+     * Expires data older than the specified threshold in milliseconds.
      *
      * For each category, this method performs a readonly cursor scan to identify candidate
      * records, decrypts encrypted entries to inspect their timestamps, and then deletes the
@@ -864,21 +864,21 @@ class LocalSave {
      * If decryption fails during expiration and `clearOnDecryptError` is enabled, the category
      * is cleared before the error is rethrown.
      *
-     * @param {number} [days=this.expiryThreshold] The number of days to use as the threshold for expiring data.
+     * @param {number} [thresholdMs=this.expiryThreshold] The threshold in milliseconds to use for expiring data.
      * Defaults to expiryThreshold from config if not provided.
      *
      * @returns A promise that resolves to `true` if the operation was successful.
      *
      * @throws {LocalSaveError} - Throws an error if there is an issue scanning entries, decrypting data, or removing expired items.
      */
-    async expire(days: number = this.expiryThreshold): Promise<true> {
+    async expire(thresholdMs: number = this.expiryThreshold): Promise<true> {
         if (this.printLogs) {
-            Logger.debug(`expire() called to expire data older than ${days} days`);
+            Logger.debug(`expire() called to expire data older than ${thresholdMs} ms`);
         }
-        if (typeof days !== 'number' || !Number.isFinite(days) || days <= 0) {
-            throw new LocalSaveError('days should be a positive number');
+        if (typeof thresholdMs !== 'number' || !Number.isFinite(thresholdMs) || thresholdMs <= 0) {
+            throw new LocalSaveError('thresholdMs should be a positive number');
         }
-        const checkDate = Date.now() - days * 86400000;
+        const checkDate = Date.now() - thresholdMs;
         for (const category of this.categories) {
             const store = await this.getStore(category);
             try {
@@ -1047,7 +1047,7 @@ class LocalSave {
                 });
             } catch (error) {
                 if (this.printLogs) {
-                    Logger.error(`Expiring data older than '${days}' days failed`, error);
+                    Logger.error(`Expiring data older than '${thresholdMs}' ms failed`, error);
                 }
                 throw error;
             }
@@ -1182,9 +1182,10 @@ export interface Config {
      */
     categories?: Category[];
     /**
-     * The number of days to use as the threshold for expiring data
+     * The threshold in milliseconds for expiring data.
      *
-     * @default 30
+     * Total = days * hours * minutes * seconds * milliseconds
+     * @default 30 * 24 * 60 * 60 * 1000 = 2592000000
      */
     expiryThreshold?: PositiveNumber;
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1184,8 +1184,10 @@ export interface Config {
     /**
      * The threshold in milliseconds for expiring data.
      *
-     * Total = days * hours * minutes * seconds * milliseconds
-     * @default 30 * 24 * 60 * 60 * 1000 = 2592000000
+     * Example day-to-ms conversion: days * 24 * 60 * 60 * 1000
+     *
+     * Default is 30 days - 30 * 24 * 60 * 60 * 1000
+     * @default 2592000000
      */
     expiryThreshold?: PositiveNumber;
     /**

--- a/src/test/integration/local-save.integration.test.ts
+++ b/src/test/integration/local-save.integration.test.ts
@@ -419,7 +419,7 @@ describe('LocalSave - Integration', { tags: ['integration'] }, ({ beforeEach, af
 
         vi.setSystemTime(baseTime.getTime() + 2 * 24 * 60 * 60 * 1000);
 
-        debugLog('Setting fresh item two days after base time (in ms)');
+        debugLog('Setting fresh item two days after base time');
         const freshSetResult = await localSave.set('userData', freshKey, freshData);
         debugLog(`Validating set() result for fresh item\nExpected: true\nActual: ${freshSetResult}`);
         expect(freshSetResult).toBe(true);

--- a/src/test/integration/local-save.integration.test.ts
+++ b/src/test/integration/local-save.integration.test.ts
@@ -419,7 +419,7 @@ describe('LocalSave - Integration', { tags: ['integration'] }, ({ beforeEach, af
 
         vi.setSystemTime(baseTime.getTime() + 2 * 24 * 60 * 60 * 1000);
 
-        debugLog('Setting fresh item two days after base time');
+        debugLog('Setting fresh item two days after base time (in ms)');
         const freshSetResult = await localSave.set('userData', freshKey, freshData);
         debugLog(`Validating set() result for fresh item\nExpected: true\nActual: ${freshSetResult}`);
         expect(freshSetResult).toBe(true);
@@ -431,8 +431,8 @@ describe('LocalSave - Integration', { tags: ['integration'] }, ({ beforeEach, af
         );
         expect(keysBeforeExpire).toEqual(expect.arrayContaining([staleKey, freshKey]));
 
-        debugLog('Expiring data older than 1 day');
-        const expireResult = await localSave.expire(1);
+        debugLog('Expiring data older than 1 day in milliseconds');
+        const expireResult = await localSave.expire(24 * 60 * 60 * 1000);
         debugLog(`Validating expire() result\nExpected: true\nActual: ${expireResult}`);
         expect(expireResult).toBe(true);
 
@@ -477,8 +477,8 @@ describe('LocalSave - Integration', { tags: ['integration'] }, ({ beforeEach, af
         debugLog(`Validating overwrite set() result\nExpected: true\nActual: ${overwriteResult}`);
         expect(overwriteResult).toBe(true);
 
-        debugLog('Expiring data older than 1 day');
-        const expireResult = await localSave.expire(1);
+        debugLog('Expiring data older than 1 day in milliseconds');
+        const expireResult = await localSave.expire(24 * 60 * 60 * 1000);
         debugLog(`Validating expire() result\nExpected: true\nActual: ${expireResult}`);
         expect(expireResult).toBe(true);
 

--- a/src/test/unit/local-save.config.test.ts
+++ b/src/test/unit/local-save.config.test.ts
@@ -22,8 +22,8 @@ describe('LocalSave - Configuration', { tags: ['config'] }, ({ beforeEach, after
             `Validating property 'categories'\nExpected: ["userData"]\nActual: ${JSON.stringify(localSave.categories)}`,
         );
         expect(localSave.categories).toEqual(['userData']);
-        debugLog(`Validating property 'expiryThreshold'\nExpected: 30\nActual: ${localSave.expiryThreshold}`);
-        expect(localSave.expiryThreshold).toBe(30);
+        debugLog(`Validating property 'expiryThreshold'\nExpected: 2592000000\nActual: ${localSave.expiryThreshold}`);
+        expect(localSave.expiryThreshold).toBe(30 * 24 * 60 * 60 * 1000);
         debugLog(`Validating property 'clearOnDecryptError'\nExpected: true\nActual: ${localSave.clearOnDecryptError}`);
         expect(localSave.clearOnDecryptError).toBe(true);
         debugLog(`Validating property 'printLogs'\nExpected: false\nActual: ${localSave.printLogs}`);
@@ -38,7 +38,7 @@ describe('LocalSave - Configuration', { tags: ['config'] }, ({ beforeEach, after
             encryptionKey: '75Q1SDWH1B6KJIP6',
             categories: ['session', 'cache'],
             clearOnDecryptError: false,
-            expiryThreshold: 7,
+            expiryThreshold: 7000,
             blockedTimeoutThreshold: 15000,
             printLogs: true,
         });
@@ -50,8 +50,8 @@ describe('LocalSave - Configuration', { tags: ['config'] }, ({ beforeEach, after
             `Validating property 'categories'\nExpected: ["session", "cache"]\nActual: ${JSON.stringify(localSave.categories)}`,
         );
         expect(localSave.categories).toEqual(['session', 'cache']);
-        debugLog(`Validating property 'expiryThreshold'\nExpected: 7\nActual: ${localSave.expiryThreshold}`);
-        expect(localSave.expiryThreshold).toBe(7);
+        debugLog(`Validating property 'expiryThreshold'\nExpected: 7000\nActual: ${localSave.expiryThreshold}`);
+        expect(localSave.expiryThreshold).toBe(7000);
         debugLog(
             `Validating property 'clearOnDecryptError'\nExpected: false\nActual: ${localSave.clearOnDecryptError}`,
         );
@@ -72,7 +72,7 @@ describe('LocalSave - Configuration', { tags: ['config'] }, ({ beforeEach, after
         try {
             localSave = new LocalSave({
                 encryptionKey: 'FXSVGSVFX5KE6LSTZU535JC0H6OXY4KI',
-                expiryThreshold: 15,
+                expiryThreshold: 15000,
                 blockedTimeoutThreshold: 20000,
             });
         } catch (error) {
@@ -81,7 +81,7 @@ describe('LocalSave - Configuration', { tags: ['config'] }, ({ beforeEach, after
         debugLog(`Validating error\nExpected: undefined\nActual: ${String(thrownError)}`);
         expect(thrownError).toBeUndefined();
         expect(localSave?.encryptionKey).toBe('FXSVGSVFX5KE6LSTZU535JC0H6OXY4KI');
-        expect(localSave?.expiryThreshold).toBe(15);
+        expect(localSave?.expiryThreshold).toBe(15000);
         expect(localSave?.blockedTimeoutThreshold).toBe(20000);
 
         if (localSave) {

--- a/src/test/unit/local-save.instance.test.ts
+++ b/src/test/unit/local-save.instance.test.ts
@@ -154,7 +154,7 @@ describe('LocalSave - Instance', { tags: ['instance'] }, ({ beforeEach, afterEac
         vi.useFakeTimers();
         const baseTime = new Date();
         vi.setSystemTime(baseTime);
-        const localSave = new LocalSave({ expiryThreshold: 1, printLogs: isDebugLogsEnabled() });
+        const localSave = new LocalSave({ expiryThreshold: 24 * 60 * 60 * 1000, printLogs: isDebugLogsEnabled() });
         debugLog('Setting data for multiple keys using set() method');
         await localSave.set('userData', randomKeys[0], randomValues);
         await localSave.set('userData', randomKeys[1], randomValues);
@@ -165,7 +165,7 @@ describe('LocalSave - Instance', { tags: ['instance'] }, ({ beforeEach, afterEac
         expect(keysResultPreExpire).toHaveLength(2);
         vi.setSystemTime(baseTime.getTime() + 2 * 24 * 60 * 60 * 1000);
         debugLog(`Expiring items using expire() method`);
-        const expireResult = await localSave.expire(1);
+        const expireResult = await localSave.expire(24 * 60 * 60 * 1000);
         debugLog(`Validating result of expire() method\nExpected: true\nActual: ${expireResult}`);
         expect(expireResult).toBe(true);
         const keysResult = await localSave.listKeys('userData');


### PR DESCRIPTION
## Summary
This PR standardizes expiration handling to milliseconds across LocalSave so all time-based configuration uses the same unit.

## What changed
- Switched expiryThreshold semantics from days to milliseconds in the core library.
- Updated the default expiry threshold to:
  - 30 * 24 * 60 * 60 * 1000
  - Equivalent total: 2592000000 ms
- Updated expire() parameter semantics from day-based input to millisecond-based input.
- Updated logging and inline documentation to reflect millisecond units.
- Updated unit and integration tests to use millisecond thresholds.
- Updated README examples and option table to show millisecond usage.
- Updated repository Copilot guidance to remove outdated day-based notes.

## Breaking change
Yes. expire() input is now interpreted as milliseconds instead of days.

## Migration notes
- Before:
  - expire(14) meant 14 days
  - expiryThreshold: 14 meant 14 days
- After:
  - expire(14 * 24 * 60 * 60 * 1000) means 14 days
  - expiryThreshold: 14 * 24 * 60 * 60 * 1000 means 14 days

## Validation
- Lint passed
- Tests passed (all existing tests)
- Build passed

## Scope
Library, tests, and docs only. No demo updates included in this PR.